### PR TITLE
Fix input auto zoom on iOS

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -115,7 +115,6 @@ const Index = ({ schedule }) => {
             onChange={(e) => {
               setSearchBy(e.target.value);
             }}
-            fontSize={[14, 16]}
           >
             <option value="kecamatan">Kecamatan</option>
             <option value="kelurahan">Kelurahan</option>
@@ -124,7 +123,6 @@ const Index = ({ schedule }) => {
             placeholder="cari kecamatan / kelurahan"
             value={searchKeyword}
             onChange={(e) => setSearchKeyword(e.target.value)}
-            fontSize={[14, 16]}
           ></Input>
         </Flex>
 


### PR DESCRIPTION
regression from #3, clicking on search input should not zoom the viewport.

iOS Safari expects input elements font size to be 16px or else it will auto zoom. Alterntive solution is to disable zoom entirely which is not ideal 🤷