### PR TITLE
Add runtime type validation using runtypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-mapbox-gl": "^5.1.1",
-    "rooks": "^5.0.2"
+    "rooks": "^5.0.2",
+    "runtypes": "^6.3.1"
   },
   "devDependencies": {
     "@chakra-ui/theme-tools": "^1.1.7",

--- a/src/components/VaxLocation.tsx
+++ b/src/components/VaxLocation.tsx
@@ -29,7 +29,7 @@ import {
   Wrap,
   WrapItem
 } from '@chakra-ui/react';
-import { DetailLokasi, VaccinationData } from 'data/types';
+import { DetailLokasi, Kuota, VaccinationData } from 'data/types';
 import { formatDistanceToNow } from 'date-fns';
 import idLocale from 'date-fns/locale/id';
 
@@ -67,7 +67,7 @@ export default function VaxLocation({ loading, location, isUserLocationExist }: 
   const mapsUrl = detail_lokasi?.[0]
     ? `https://www.google.com/maps/search/${encodeURIComponent(`${detail_lokasi[0].lat}, ${detail_lokasi[0].lon}`)}`
     : `https://www.google.com/maps/search/${encodeURIComponent(namaLokasi)}`;
-  const isCurrentLocationHasQuota = hasQuota(jadwal ?? []);
+  const isCurrentLocationHasQuota = hasQuota(jadwal);
 
   const renderLocationDetail = () => {
     if (!loading && isUserLocationExist && typeof detail_lokasi !== 'undefined' && detail_lokasi.length > 0) {
@@ -103,7 +103,7 @@ export default function VaxLocation({ loading, location, isUserLocationExist }: 
         {!isCurrentLocationHasQuota && <Text color="red">Kuota Habis</Text>}
         <Spacer />
         <Wrap>
-          {jadwal?.map(({ id: jadwalId, waktu }) => (
+          {jadwal.map(({ id: jadwalId, waktu }) => (
             <WrapItem key={jadwalId}>
               <Popover isLazy>
                 <PopoverTrigger>
@@ -123,7 +123,7 @@ export default function VaxLocation({ loading, location, isUserLocationExist }: 
                         </Tr>
                       </Thead>
                       <Tbody>
-                        {waktu?.map(({ label, id, kuota }) => {
+                        {waktu.map(({ label, id, kuota }) => {
                           // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
                           const { sisaKuota = 0, totalKuota = 0 } = kuota || {};
                           return (

--- a/src/components/VaxLocation.tsx
+++ b/src/components/VaxLocation.tsx
@@ -125,7 +125,7 @@ export default function VaxLocation({ loading, location, isUserLocationExist }: 
                       <Tbody>
                         {waktu.map(({ label, id, kuota }) => {
                           // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                          const { sisaKuota = 0, totalKuota = 0 } = kuota || {};
+                          const { sisaKuota = 0, totalKuota = 0 } = kuota as Kuota;
                           return (
                             <Tr key={id}>
                               <Td>{label}</Td>

--- a/src/data/getSchedule.ts
+++ b/src/data/getSchedule.ts
@@ -11,7 +11,7 @@ const getSchedule = async () => {
   // give warning to console if the validation is not success.
   // change it to more strict one if the API is already stable
   if (!validation.success) {
-    console.error(validation);
+    console.error('Contract Error: /n', validation);
   }
 
   return json;

--- a/src/data/getSchedule.ts
+++ b/src/data/getSchedule.ts
@@ -1,4 +1,4 @@
-import { VaccinationData } from './types';
+import { VaccinationData, VaccinationDataRt } from './types';
 
 import fetch from 'isomorphic-unfetch';
 
@@ -7,6 +7,12 @@ const SCHEDULE_ENDPOINT = `https://vaksin-jakarta.yggdrasil.id/`;
 const getSchedule = async () => {
   const payload = await fetch(SCHEDULE_ENDPOINT);
   const json = (await payload.json()) as VaccinationData[];
+  const validation = VaccinationDataRt.validate(json);
+  // give warning to console if the validation is not success.
+  // change it to more strict one if the API is already stable
+  if (!validation.success) {
+    console.error(validation);
+  }
 
   return json;
 };

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -3,7 +3,8 @@ import * as rt from 'runtypes';
 export const KuotaRt = rt.Record({
   totalKuota: rt.Union(rt.Null, rt.Number),
   sisaKuota: rt.Union(rt.Null, rt.Number),
-  jakiKuota: rt.Union(rt.Null, rt.Number)
+  // the value is string and it's deprecated https://github.com/tibudiyanto/jakarta-vax-availability/issues/53#issuecomment-874673016
+  jakiKuota: rt.Union(rt.Null, rt.String)
 });
 
 export const WaktuRt = rt.Record({

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -1,56 +1,71 @@
-export interface VaccinationData {
-  kode_lokasi_vaksinasi: number;
-  nama_lokasi_vaksinasi: string;
-  alamat_lokasi_vaksinasi: string;
-  wilayah: string;
-  kecamatan: string;
-  kelurahan: string;
-  rt: string;
-  rw: string;
-  kodepos: string;
-  jenis_faskes: string;
-  jumlah_tim_vaksinator: number;
-  nama_faskes: string;
-  created_at?: null;
-  updated_at?: null;
-  pcare: boolean;
-  jadwal?: Jadwal[] | null;
-  detail_lokasi?: (DetailLokasi | null)[] | null;
-  last_updated_at: string;
-}
-export interface Jadwal {
-  id: string;
-  label: string;
-  kode_lokasi_vaksinasi: number;
-  waktu?: Waktu[] | null;
-}
+import * as rt from 'runtypes';
 
-export interface Waktu {
-  id: string;
-  label: string;
-  kuota: Kuota;
-}
+export const KuotaRt = rt.Record({
+  totalKuota: rt.Union(rt.Null, rt.Number),
+  sisaKuota: rt.Union(rt.Null, rt.Number),
+  jakiKuota: rt.Union(rt.Null, rt.Number)
+});
 
-export interface Kuota {
-  totalKuota?: number | null;
-  sisaKuota?: number | null;
-  jakiKuota?: number | null;
-}
+export const WaktuRt = rt.Record({
+  id: rt.String,
+  label: rt.String,
+  kuota: KuotaRt.Or(rt.Record({}))
+});
 
-export interface DetailLokasi {
-  place_id: number;
-  licence: string;
-  osm_type: string;
-  osm_id: number;
-  boundingbox?: string[] | null;
-  lat: string;
-  lon: string;
-  display_name: string;
-  place_rank: number;
-  category: string;
-  type: string;
-  importance: number;
-}
+export const JadwalRt = rt.Record({
+  id: rt.String,
+  label: rt.String,
+  kode_lokasi_vaksinasi: rt.Number,
+  waktu: rt.Array(WaktuRt)
+});
+
+export const DetailLokasiRt = rt.Record({
+  place_id: rt.Number,
+  licence: rt.String,
+  osm_type: rt.String,
+  osm_id: rt.Number,
+  boundingbox: rt.Array(rt.String),
+  lat: rt.String,
+  lon: rt.String,
+  display_name: rt.String,
+  place_rank: rt.Number,
+  category: rt.String,
+  type: rt.String,
+  importance: rt.Number
+});
+
+export const VacctinationRt = rt.Record({
+  kode_lokasi_vaksinasi: rt.Number,
+  nama_lokasi_vaksinasi: rt.String,
+  alamat_lokasi_vaksinasi: rt.String,
+  wilayah: rt.String,
+  kecamatan: rt.String,
+  kelurahan: rt.String,
+  rt: rt.String,
+  rw: rt.String,
+  kodepos: rt.String,
+  jenis_faskes: rt.String,
+  jumlah_tim_vaksinator: rt.Union(rt.Number, rt.Null),
+  nama_faskes: rt.String,
+  created_at: rt.Union(rt.Null, rt.String),
+  updated_at: rt.Union(rt.Null, rt.String),
+  pcare: rt.Boolean,
+  jadwal: rt.Array(JadwalRt),
+  detail_lokasi: rt.Array(DetailLokasiRt),
+  last_updated_at: rt.String
+});
+
+export const VaccinationDataRt = rt.Array(VacctinationRt);
+
+export type VaccinationData = rt.Static<typeof VacctinationRt>;
+
+export type Jadwal = rt.Static<typeof JadwalRt>;
+
+export type Waktu = rt.Static<typeof WaktuRt>;
+
+export type DetailLokasi = rt.Static<typeof DetailLokasiRt>;
+
+export type Kuota = rt.Static<typeof KuotaRt>;
 
 export interface Coordinate {
   lat: number;

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -51,7 +51,7 @@ export const VacctinationRt = rt.Record({
   updated_at: rt.Union(rt.Null, rt.String),
   pcare: rt.Boolean,
   jadwal: rt.Array(JadwalRt),
-  detail_lokasi: rt.Array(DetailLokasiRt),
+  detail_lokasi: rt.Array(DetailLokasiRt).Or(rt.Null),
   last_updated_at: rt.String
 });
 

--- a/src/helpers/QuotaHelpers.ts
+++ b/src/helpers/QuotaHelpers.ts
@@ -1,4 +1,4 @@
-import { Jadwal } from 'data/types';
+import { Jadwal, KuotaRt } from 'data/types';
 
 export function hasQuota(jadwal: Jadwal[] = []) {
   for (const jadwalItem of jadwal) {

--- a/src/helpers/QuotaHelpers.ts
+++ b/src/helpers/QuotaHelpers.ts
@@ -2,9 +2,9 @@ import { Jadwal, KuotaRt } from 'data/types';
 
 export function hasQuota(jadwal: Jadwal[] = []) {
   for (const jadwalItem of jadwal) {
-    for (const waktuItem of jadwalItem.waktu ?? []) {
-      const { kuota = {} } = waktuItem;
-      if (kuota.sisaKuota || kuota.totalKuota) {
+    for (const waktuItem of jadwalItem.waktu) {
+      const { kuota } = waktuItem;
+      if (KuotaRt.guard(kuota) && (kuota.sisaKuota || kuota.totalKuota)) {
         return true;
       }
     }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -100,21 +100,21 @@ export default function HomePage({ schedule }: Props) {
           .map(item => ({
             ...item,
             detail_lokasi:
-              (item.detail_lokasi?.length || 0) > 0
+              (item.detail_lokasi.length || 0) > 0
                 ? item.detail_lokasi
-                    ?.map(loc => ({
+                    .map(loc => ({
                       ...loc,
                       distance: getDistanceFromLatLonInKm(
                         userLocation.lat,
                         userLocation.lon,
-                        Number(loc?.lat),
-                        Number(loc?.lon)
+                        Number(loc.lat),
+                        Number(loc.lon)
                       )
                     }))
                     .sort((a, b) => (a.distance > b.distance ? 1 : -1))
                 : item.detail_lokasi
           }))
-          // @ts-expect-error `distance` is added to `detail_lokasi` in the previous .map() call
+          // `distance` is added to `detail_lokasi` in the previous .map() call
           .sort((a: VaccinationDataWithDistance, b: VaccinationDataWithDistance) => {
             if (!a.detail_lokasi?.[0]) {
               return 1;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -100,9 +100,9 @@ export default function HomePage({ schedule }: Props) {
           .map(item => ({
             ...item,
             detail_lokasi:
-              (item.detail_lokasi.length || 0) > 0
+              (item.detail_lokasi?.length || 0) > 0
                 ? item.detail_lokasi
-                    .map(loc => ({
+                    ?.map(loc => ({
                       ...loc,
                       distance: getDistanceFromLatLonInKm(
                         userLocation.lat,
@@ -114,7 +114,7 @@ export default function HomePage({ schedule }: Props) {
                     .sort((a, b) => (a.distance > b.distance ? 1 : -1))
                 : item.detail_lokasi
           }))
-          // `distance` is added to `detail_lokasi` in the previous .map() call
+          // @ts-expect-error `distance` is added to `detail_lokasi` in the previous .map() call
           .sort((a: VaccinationDataWithDistance, b: VaccinationDataWithDistance) => {
             if (!a.detail_lokasi?.[0]) {
               return 1;

--- a/src/pages/map.tsx
+++ b/src/pages/map.tsx
@@ -18,6 +18,7 @@ import {
   PopoverContent,
   PopoverHeader,
   PopoverTrigger,
+  Select,
   useColorMode,
   useColorModeValue
 } from '@chakra-ui/react';

--- a/src/pages/map.tsx
+++ b/src/pages/map.tsx
@@ -18,7 +18,6 @@ import {
   PopoverContent,
   PopoverHeader,
   PopoverTrigger,
-  Select,
   useColorMode,
   useColorModeValue
 } from '@chakra-ui/react';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4466,6 +4466,11 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
+runtypes@^6.3.1:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/runtypes/-/runtypes-6.3.1.tgz#58566dde275e60d762f3cc0d7036d5cb0b79a8d1"
+  integrity sha512-XMroIPFshQw4A41tfvcpMECESJSydiIGxDtQZxryFZMfL6QGYuoBjixIpQj2vL1MJSIbrcgQnw/1tzfyABmVkg==
+
 rw@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"


### PR DESCRIPTION
I add runtypes to documenting what is returned to API. So maybe it helps. 

- [x] adding runtypes
- [x] add guard on `hasQuota` and `getSchedule`  

