### PR TITLE
Fixing site breaking if kuota is undefined

### DIFF
--- a/src/components/VaxLocation.tsx
+++ b/src/components/VaxLocation.tsx
@@ -67,8 +67,8 @@ export default function VaxLocation({ loading, location, isUserLocationExist }: 
     detail_lokasi?.[0] == null
       ? `https://www.google.com/maps/search/${encodeURIComponent(namaLokasi)}`
       : `https://www.google.com/maps/search/${encodeURIComponent(
-        `${detail_lokasi[0]?.lat}, ${detail_lokasi[0]?.lon}`
-      )}`;
+          `${detail_lokasi[0]?.lat}, ${detail_lokasi[0]?.lon}`
+        )}`;
   const isCurrentLocationHasQuota = hasQuota(jadwal ?? []);
 
   return (
@@ -124,7 +124,7 @@ export default function VaxLocation({ loading, location, isUserLocationExist }: 
                       </Thead>
                       <Tbody>
                         {waktu?.map(({ label, id, kuota }) => {
-                          const { sisaKuota = 0, jakiKuota = 0, totalKuota = 0 } = kuota;
+                          const { sisaKuota = 0, jakiKuota = 0, totalKuota = 0 } = kuota || {};
                           return (
                             <Tr key={id}>
                               <Td>{label}</Td>


### PR DESCRIPTION
If kuota is somehow undefined from the API (eg, perhaps if all locations have no kuota), the site breaks, so this PR fixes that (hopefully)

<img width="949" alt="Screen Shot 2021-07-06 at 11 40 28" src="https://user-images.githubusercontent.com/168755/124543326-42d57480-de4f-11eb-86c3-4ea949b85d4f.png">
