### PR TITLE
re-enable eslint on lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "license": "MIT",
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
+      "eslint --cache --fix",
       "prettier --write"
     ],
     "*.{css,scss,md,html}": [


### PR DESCRIPTION
Now that all our code is properly linted, we should bring this back.