### PR TITLE
wip: virtualized vax list

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-mapbox-gl": "^5.1.1",
+    "react-virtualized-auto-sizer": "^1.0.5",
+    "react-window": "^1.8.6",
     "rooks": "^5.0.2",
     "runtypes": "^6.3.1"
   },

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,14 +1,16 @@
 import config from '~config';
 
-import { Link, Stack, Text } from '@chakra-ui/react';
+import { Box, Link, Stack, Text } from '@chakra-ui/react';
 
 export default function Footer() {
   return (
-    <Stack align="center" fontSize="sm" justify="center" px={2} py={[8, 16]} spacing={1} textAlign="center">
-      <Text>Made using Next.js and Chakra UI. Hosted on Vercel.</Text>
-      <Link color="blue.300" href={config.repoUrl} isExternal>
-        View repository
-      </Link>
-    </Stack>
+    <Box bottom={0} left={0} position="fixed" right={0}>
+      <Stack align="center" fontSize="sm" justify="center" px={2} py={[8, 16]} spacing={1} textAlign="center">
+        <Text>Made using Next.js and Chakra UI. Hosted on Vercel.</Text>
+        <Link color="blue.300" href={config.repoUrl} isExternal>
+          View repository
+        </Link>
+      </Stack>
+    </Box>
   );
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 
-import Footer from '~components/Footer';
 import ToggleColorMode from '~components/ToggleColorMode';
 import theme from '~theme';
 
@@ -8,10 +7,7 @@ import { ChakraProvider } from '@chakra-ui/react';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
 
-export default function MyApp({ Component, pageProps, router }: AppProps) {
-  // Hide footer in map page
-  const isNotMapPage = React.useMemo(() => router.asPath !== '/map', [router.asPath]);
-
+export default function MyApp({ Component, pageProps }: AppProps) {
   return (
     <>
       <Head>
@@ -20,7 +16,6 @@ export default function MyApp({ Component, pageProps, router }: AppProps) {
       <ChakraProvider resetCSS theme={theme}>
         <ToggleColorMode />
         <Component {...pageProps} />
-        {isNotMapPage && <Footer />}
       </ChakraProvider>
     </>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3516,6 +3516,11 @@ md5.js@^1.3.4:
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
 
+"memoize-one@>=3.1.1 <6":
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
+  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
+
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
@@ -4293,6 +4298,19 @@ react-style-singleton@^2.1.0:
     get-nonce "^1.0.0"
     invariant "^2.2.4"
     tslib "^1.0.0"
+
+react-virtualized-auto-sizer@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.5.tgz#9eeeb8302022de56fbd7a860b08513120ce36509"
+  integrity sha512-kivjYVWX15TX2IUrm8F1jaCEX8EXrpy3DD+u41WGqJ1ZqbljWpiwscV+VxOM1l7sSIM1jwi2LADjhhAJkJ9dxA==
+
+react-window@^1.8.6:
+  version "1.8.6"
+  resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.8.6.tgz#d011950ac643a994118632665aad0c6382e2a112"
+  integrity sha512-8VwEEYyjz6DCnGBsd+MgkD0KJ2/OXFULyDtorIiTz+QzwoP94tBoA7CnbtyXMm+cCeAUER5KJcPtWl9cpKbOBg==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    memoize-one ">=3.1.1 <6"
 
 react@^17.0.2:
   version "17.0.2"


### PR DESCRIPTION
resolve #67 

Implement virtualized list using `VariableSizeGrid` with 2 column. This is currently hardcoded as we probably need some kind of media query to switch to single column grid (still not sure the best way to handle this)

**Some notes**
- Grid height is calculated based on number of schedule available in the vax location
- We use the `filteredSchedule` itself as key to make sure that the virtual list re-renders on query change

## To do
- [ ] make it responsive
- [ ] put footer back / remove entirely 

## Trade Off

- Footer must be fixed / removed entirely
- Scroll not on body

## Before
![image](https://user-images.githubusercontent.com/1614415/124908770-e1123780-e013-11eb-90ec-7aa4c9862b32.png)

## After
![image](https://user-images.githubusercontent.com/1614415/124925306-7f0efd80-e026-11eb-97db-bdc03108892e.png)

also resolve #70 