### PR TITLE
client-side pagination

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -62,7 +62,7 @@ export default function HomePage({ schedule }: Props) {
     return () => {
       router.events.off('hashChangeStart', handleHashChange);
     };
-  });
+  }, []);
 
   const getUserLocation = () => {
     setUserLocation(prev => ({ ...prev, loading: true }));
@@ -175,7 +175,7 @@ export default function HomePage({ schedule }: Props) {
     getUserLocation();
   };
 
-  const currentPageStartIndex = currentPage * PAGE_SIZE;
+  const currentPageStartIndex = (currentPage - 1) * PAGE_SIZE;
   const paginatedFilteredSchedule = filteredSchedule.slice(currentPageStartIndex, currentPageStartIndex + PAGE_SIZE);
   const numberOfPage = Math.floor(filteredSchedule.length / PAGE_SIZE);
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -227,7 +227,7 @@ export default function HomePage({ schedule }: Props) {
                 .map((_, i) => (
                   <Button
                     key={i + 1}
-                    onClick={() => setCurrentPage(i + 1)}
+                    onClick={() => router.push(`#page=${i + 1}`)}
                     variant={currentPage === i + 1 ? 'solid' : 'ghost'}
                   >
                     {i + 1}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -175,6 +175,15 @@ export default function HomePage({ schedule }: Props) {
     getUserLocation();
   };
 
+  const handleChangeKeyword = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchKeyword(e.target.value);
+
+    // reset page to 1
+    if (currentPage !== 1) {
+      router.push(`/`);
+    }
+  };
+
   const currentPageStartIndex = (currentPage - 1) * PAGE_SIZE;
   const paginatedFilteredSchedule = filteredSchedule.slice(currentPageStartIndex, currentPageStartIndex + PAGE_SIZE);
   const numberOfPage = Math.floor(filteredSchedule.length / PAGE_SIZE);
@@ -197,7 +206,7 @@ export default function HomePage({ schedule }: Props) {
           >
             {userLocation.lat && userLocation.lon ? 'Lokasi Ditemukan' : 'Dapatkan Lokasi Anda'}
           </Button>
-          <Searchbox keyword={searchKeyword} onChange={e => setSearchKeyword(e.target.value)} />
+          <Searchbox keyword={searchKeyword} onChange={handleChangeKeyword} />
           <Link href="/map" passHref prefetch={false}>
             <Button
               as="a"
@@ -229,11 +238,12 @@ export default function HomePage({ schedule }: Props) {
                 .map((_, i) => (
                   <Button
                     key={i + 1}
-                    onClick={() =>
-                      router.push(`/#page=${i + 1}`).then(() => {
+                    onClick={() => {
+                      const nextPage = i === 0 ? `/` : `/#page=${i + 1}`;
+                      router.push(nextPage).then(() => {
                         window.scrollTo({ top: 0, behavior: 'smooth' });
-                      })
-                    }
+                      });
+                    }}
                     variant={currentPage === i + 1 ? 'solid' : 'ghost'}
                   >
                     {i + 1}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -177,7 +177,7 @@ export default function HomePage({ schedule }: Props) {
 
   const currentPageStartIndex = currentPage * PAGE_SIZE;
   const paginatedFilteredSchedule = filteredSchedule.slice(currentPageStartIndex, currentPageStartIndex + PAGE_SIZE);
-  const numberOfPage = Math.ceil(filteredSchedule.length / PAGE_SIZE);
+  const numberOfPage = Math.floor(filteredSchedule.length / PAGE_SIZE);
 
   return (
     <>
@@ -211,30 +211,36 @@ export default function HomePage({ schedule }: Props) {
           </Link>
         </Stack>
         <Container as="section" maxW="container.lg" px={0} w="full">
-          <SimpleGrid as="ul" columns={[1, null, null, 2]} listStyleType="none" spacing={4} w="full">
-            {paginatedFilteredSchedule.map((location: VaccinationDataWithDistance, i: number) => (
-              <Box key={i} as="li" w="full">
-                <VaxLocation
-                  isUserLocationExist={Boolean(userLocation.lat && userLocation.lon)}
-                  loading={userLocation.loading}
-                  location={location}
-                />
-              </Box>
-            ))}
+          <Stack spacing={4}>
+            <SimpleGrid as="ul" columns={[1, null, null, 2]} listStyleType="none" spacing={4} w="full">
+              {paginatedFilteredSchedule.map((location: VaccinationDataWithDistance, i: number) => (
+                <Box key={i} as="li" w="full">
+                  <VaxLocation
+                    isUserLocationExist={Boolean(userLocation.lat && userLocation.lon)}
+                    loading={userLocation.loading}
+                    location={location}
+                  />
+                </Box>
+              ))}
+            </SimpleGrid>
             <HStack justify="center" role="group" spacing={[0, 4]}>
               {Array(numberOfPage)
                 .fill(0)
                 .map((_, i) => (
                   <Button
                     key={i + 1}
-                    onClick={() => router.push(`#page=${i + 1}`)}
+                    onClick={() =>
+                      router.push(`/#page=${i + 1}`).then(() => {
+                        window.scrollTo({ top: 0, behavior: 'smooth' });
+                      })
+                    }
                     variant={currentPage === i + 1 ? 'solid' : 'ghost'}
                   >
                     {i + 1}
                   </Button>
                 ))}
             </HStack>
-          </SimpleGrid>
+          </Stack>
         </Container>
       </Stack>
     </>


### PR DESCRIPTION
do pagination on client-side to reduce initial render time #67, this is an alternative solution of #73.

If this works, this PR can be used as base of future improvement as described in
 - https://twitter.com/pveyes/status/1413136446035140613?s=20
 - https://twitter.com/tibudiyanto/status/1413137291975925766?s=20

![image](https://user-images.githubusercontent.com/1614415/124952222-3e22e300-e03e-11eb-8257-0a77a2f33c53.png)

This PR renders pagination naively, which means if there's 100 page, there will be 100 button. We can do follow up PR later to collapse this into ... if more than X page

p.s: partially authored by copilot