### PR TITLE
perf(bundle): reduce 2kb with next dynamic import

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 
-import Footer from '~components/Footer';
-import ToggleColorMode from '~components/ToggleColorMode';
 import theme from '~theme';
 
 import { ChakraProvider } from '@chakra-ui/react';
 import type { AppProps } from 'next/app';
+import dynamic from 'next/dynamic';
 import Head from 'next/head';
+
+const Footer = dynamic(() => import('~components/Footer'));
+const ToggleColorMode = dynamic(() => import('~components/ToggleColorMode'));
 
 export default function MyApp({ Component, pageProps, router }: AppProps) {
   // Hide footer in map page

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,14 +2,12 @@ import * as React from 'react';
 
 import { getSchedule } from '~data/getSchedule';
 import type { VaccinationDataWithDistance } from '~modules/vax/types';
-import VaxLocation from '~modules/vax/VaxLocation';
-
-import Searchbox from '../components/Searchbox';
 
 import { ExternalLinkIcon } from '@chakra-ui/icons';
 import { Box, Button, Container, Heading, HStack, SimpleGrid, Stack } from '@chakra-ui/react';
 import { VaccinationData } from 'data/types';
 import useFuzzySearch from 'hooks/useFuzzySearch';
+import dynamic from 'next/dynamic';
 import Head from 'next/head';
 import Link from 'next/link';
 import Router, { useRouter } from 'next/router';
@@ -31,6 +29,9 @@ interface Props {
 const PAGE_SIZE = 20;
 
 const useIsomorphicLayoutEffect = typeof window === 'undefined' ? React.useEffect : React.useLayoutEffect;
+
+const Searchbox = dynamic(() => import('../components/Searchbox'));
+const VaxLocation = dynamic(() => import('~modules/vax/VaxLocation'));
 
 export default function HomePage({ schedule }: Props) {
   // TODO sync from hash/query


### PR DESCRIPTION
Hello @tibudiyanto  @pveyes  @resir014 

I'm just try to optimize bundle size by https://github.com/tibudiyanto/jakarta-vax-availability/issues/70 with small changes and just use `next/dynamic` import.

This is difference (before/after) when we build this project 

### Before 
![image](https://user-images.githubusercontent.com/16365952/124976790-49880580-e062-11eb-949f-71db41083da3.png)

```console
Page                                Size     First Load JS
┌ ● / (ISR: 60 Seconds)             5.2 kB          184 kB
├   /_app                           0 B             115 kB
├ ○ /404                            1.36 kB         116 kB
└ ● /map (ISR: 60 Seconds)          245 kB          423 kB
    └ css/860a9187c04c9cdfa896.css  4.58 kB
+ First Load JS shared by all       115 kB
  ├ chunks/framework.923004.js      42 kB
  ├ chunks/main.362039.js           20.4 kB
  ├ chunks/pages/_app.64e722.js     51.6 kB
  └ chunks/webpack.9fc9ab.js        857 B
```
See [lighthouse report](https://lighthouse-dot-webdotdevsite.appspot.com//lh/html?url=https%3A%2F%2Fjakarta-vax-availability.vercel.app%2F)

### After
![image](https://user-images.githubusercontent.com/16365952/124976824-5147aa00-e062-11eb-98aa-0dccde6447ab.png)

```console
Page                                Size     First Load JS
┌ ● / (ISR: 60 Seconds)             3.04 kB         127 kB
├   /_app                           0 B             108 kB
├ ○ /404                            1.36 kB         110 kB
└ ● /map (ISR: 60 Seconds)          303 kB          427 kB
    └ css/860a9187c04c9cdfa896.css  4.58 kB
+ First Load JS shared by all       108 kB
  ├ chunks/framework.d23658.js      42.2 kB
  ├ chunks/main.588261.js           20.3 kB
  ├ chunks/pages/_app.408987.js     44 kB
  └ chunks/webpack.9431a6.js        1.68 kB

```

See [lighthouse report](https://lighthouse-dot-webdotdevsite.appspot.com//lh/html?url=https%3A%2F%2Fjakarta-vax-availability-nu.vercel.app%2F)

Thank you