### PR TITLE
add vax location detail drawer

### DIFF
--- a/src/modules/vax/VaxLocation.tsx
+++ b/src/modules/vax/VaxLocation.tsx
@@ -1,14 +1,16 @@
 import * as React from 'react';
 
 import VaxLocationDetail, { VaxLocationDetailProps } from './VaxLocationDetail';
+import VaxLocationDetailDrawer from './VaxLocationDetailDrawer';
 
-import { ExternalLinkIcon } from '@chakra-ui/icons';
-import { Flex, Link, Text, useColorModeValue } from '@chakra-ui/react';
+import { CalendarIcon, ExternalLinkIcon } from '@chakra-ui/icons';
+import { Box, Flex, Link, Text, useColorModeValue, useDisclosure } from '@chakra-ui/react';
 
 type VaxLocationProps = VaxLocationDetailProps;
 
 export default function VaxLocation({ loading, location, isUserLocationExist }: VaxLocationProps) {
   const { nama_lokasi_vaksinasi: namaLokasi, detail_lokasi } = location;
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
   const borderColor = useColorModeValue('blackAlpha.200', 'whiteAlpha.200');
   const floatingButtonFocusColor = useColorModeValue('blackAlpha.100', 'whiteAlpha.100');
@@ -18,43 +20,69 @@ export default function VaxLocation({ loading, location, isUserLocationExist }: 
     : `https://www.google.com/maps/search/${encodeURIComponent(namaLokasi)}`;
 
   return (
-    <Flex borderColor={borderColor} borderRadius="md" borderWidth={1} direction="column" overflow="hidden">
-      <VaxLocationDetail isUserLocationExist={isUserLocationExist} loading={loading} location={location} />
-      <Flex
-        borderTop="1px solid"
-        borderTopColor={borderColor}
-        sx={{
-          '> :not([hidden]) ~ :not([hidden])': {
-            borderRightWidth: '1px',
-            borderLeftWidth: '1px',
-            borderColor
-          }
-        }}
-      >
-        <Flex flex="1 1 0%" w={0}>
-          <Link
-            _focus={{
-              outline: 'none',
-              backgroundColor: floatingButtonFocusColor
-            }}
-            _hover={{
-              color: 'blue.500'
-            }}
-            alignItems="center"
-            color="blue.300"
-            display="inline-flex"
-            flex="1 1 0%"
-            fontWeight="semibold"
-            href={mapsUrl}
-            isExternal
-            justifyContent="center"
-            position="relative"
-            py={4}
-          >
-            <ExternalLinkIcon aria-hidden mx={2} /> <Text>Lihat Lokasi</Text>
-          </Link>
+    <>
+      <Flex borderColor={borderColor} borderRadius="md" borderWidth={1} direction="column" overflow="hidden">
+        <VaxLocationDetail isUserLocationExist={isUserLocationExist} loading={loading} location={location} />
+        <Flex
+          borderTop="1px solid"
+          borderTopColor={borderColor}
+          sx={{
+            '> :not([hidden]) ~ :not([hidden])': {
+              borderRightWidth: '1px',
+              borderLeftWidth: '1px',
+              borderColor
+            }
+          }}
+        >
+          <Flex flex="1 1 0%" w={0}>
+            <Box
+              _focus={{
+                outline: 'none',
+                backgroundColor: floatingButtonFocusColor
+              }}
+              _hover={{
+                color: 'blue.500'
+              }}
+              alignItems="center"
+              as="button"
+              color="blue.300"
+              display="inline-flex"
+              flex="1 1 0%"
+              fontWeight="semibold"
+              justifyContent="center"
+              onClick={onOpen}
+              position="relative"
+              py={4}
+            >
+              <CalendarIcon aria-hidden mx={2} /> <Text>Lihat Jadwal</Text>
+            </Box>
+          </Flex>
+          <Flex flex="1 1 0%" w={0}>
+            <Link
+              _focus={{
+                outline: 'none',
+                backgroundColor: floatingButtonFocusColor
+              }}
+              _hover={{
+                color: 'blue.500'
+              }}
+              alignItems="center"
+              color="blue.300"
+              display="inline-flex"
+              flex="1 1 0%"
+              fontWeight="semibold"
+              href={mapsUrl}
+              isExternal
+              justifyContent="center"
+              position="relative"
+              py={4}
+            >
+              <ExternalLinkIcon aria-hidden mx={2} /> <Text>Lihat Lokasi</Text>
+            </Link>
+          </Flex>
         </Flex>
       </Flex>
-    </Flex>
+      <VaxLocationDetailDrawer isOpen={isOpen} locationData={location} onClose={onClose} />
+    </>
   );
 }

--- a/src/modules/vax/VaxLocationDetail.tsx
+++ b/src/modules/vax/VaxLocationDetail.tsx
@@ -4,7 +4,6 @@ import { Kuota } from '~/data/types';
 import { hasQuota } from '~helpers/QuotaHelpers';
 
 import { VaccinationDataWithDistance } from './types';
-import VaxLocationDetailDrawer from './VaxLocationDetailDrawer';
 
 import {
   Badge,
@@ -27,7 +26,6 @@ import {
   Tooltip,
   Tr,
   useColorMode,
-  useDisclosure,
   Wrap,
   WrapItem
 } from '@chakra-ui/react';
@@ -46,7 +44,6 @@ export interface VaxLocationDetailProps {
  */
 export default function VaxLocationDetail({ loading, isUserLocationExist, location }: VaxLocationDetailProps) {
   const { colorMode } = useColorMode();
-  const { isOpen, onOpen, onClose } = useDisclosure();
 
   const {
     nama_lokasi_vaksinasi: namaLokasi,
@@ -82,14 +79,7 @@ export default function VaxLocationDetail({ loading, isUserLocationExist, locati
   };
   return (
     <>
-      <Flex
-        alignItems="center"
-        flexDirection="row"
-        justifyContent="space-between"
-        onClick={onOpen}
-        p={4}
-        style={{ cursor: 'pointer' }}
-      >
+      <Flex alignItems="center" flexDirection="row" justifyContent="space-between" p={4}>
         <Stack spacing={2}>
           <Heading as="h2" isTruncated size="md" textTransform="capitalize" whiteSpace="break-spaces">
             {namaLokasi}
@@ -162,8 +152,6 @@ export default function VaxLocationDetail({ loading, isUserLocationExist, locati
           ))}
         </Wrap>
       </Stack>
-
-      <VaxLocationDetailDrawer isOpen={isOpen} locationData={location} onClose={onClose} />
     </>
   );
 }

--- a/src/modules/vax/VaxLocationDetail.tsx
+++ b/src/modules/vax/VaxLocationDetail.tsx
@@ -5,12 +5,20 @@ import { hasQuota } from '~helpers/QuotaHelpers';
 
 import { VaccinationDataWithDistance } from './types';
 
+import { ArrowBackIcon, ExternalLinkIcon } from '@chakra-ui/icons';
 import {
   Badge,
   Box,
   Button,
+  Divider,
+  Drawer,
+  DrawerBody,
+  DrawerContent,
+  DrawerHeader,
+  DrawerOverlay,
   Flex,
   Heading,
+  Link,
   Popover,
   PopoverArrow,
   PopoverBody,
@@ -26,10 +34,11 @@ import {
   Tooltip,
   Tr,
   useColorMode,
+  useDisclosure,
   Wrap,
   WrapItem
 } from '@chakra-ui/react';
-import { formatDistanceToNow } from 'date-fns';
+import { format, formatDistanceToNow, parse } from 'date-fns';
 import idLocale from 'date-fns/locale/id';
 
 export interface VaxLocationDetailProps {
@@ -44,10 +53,11 @@ export interface VaxLocationDetailProps {
  */
 export default function VaxLocationDetail({ loading, isUserLocationExist, location }: VaxLocationDetailProps) {
   const { colorMode } = useColorMode();
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
   const {
     nama_lokasi_vaksinasi: namaLokasi,
-    alamat_lokasi_vaksinasi: ignored_alamatLokasi,
+    alamat_lokasi_vaksinasi: alamatLokasi,
     wilayah,
     kecamatan,
     kelurahan,
@@ -78,9 +88,20 @@ export default function VaxLocationDetail({ loading, isUserLocationExist, locati
     return null;
   };
 
+  const mapsUrl = detail_lokasi?.[0]
+    ? `https://www.google.com/maps/search/${encodeURIComponent(`${detail_lokasi[0].lat}, ${detail_lokasi[0].lon}`)}`
+    : `https://www.google.com/maps/search/${encodeURIComponent(namaLokasi)}`;
+
   return (
     <>
-      <Flex alignItems="center" flexDirection="row" justifyContent="space-between" p={4}>
+      <Flex
+        alignItems="center"
+        flexDirection="row"
+        justifyContent="space-between"
+        onClick={onOpen}
+        p={4}
+        style={{ cursor: 'pointer' }}
+      >
         <Stack spacing={2}>
           <Heading as="h2" isTruncated size="md" textTransform="capitalize" whiteSpace="break-spaces">
             {namaLokasi}
@@ -153,6 +174,106 @@ export default function VaxLocationDetail({ loading, isUserLocationExist, locati
           ))}
         </Wrap>
       </Stack>
+
+      <Drawer isOpen={isOpen} onClose={onClose} placement="left" size="md">
+        <DrawerOverlay />
+        <DrawerContent>
+          <Badge
+            fontSize="0.8em"
+            onClick={() => {
+              onClose();
+            }}
+            p={4}
+            style={{ cursor: 'pointer' }}
+          >
+            <ArrowBackIcon h={4} w={4} /> Kembali
+          </Badge>
+          <DrawerHeader borderBottomWidth="1px">
+            <Text as="h1" fontSize="xl" fontWeight={700}>
+              {namaLokasi}
+            </Text>
+            <Text as="h3" color="gray.500" fontSize="xs" fontWeight={500} textTransform="capitalize">
+              {alamatLokasi
+                ? alamatLokasi.toLowerCase()
+                : `Kec. ${kecamatan.toLowerCase()}, Kel. ${kelurahan.toLowerCase()}`}
+            </Text>
+            <Text as="h3" fontSize="sm" fontWeight={600} textTransform="capitalize">
+              {wilayah.toLowerCase()}
+            </Text>
+            <Link
+              _focus={{
+                outline: 'none'
+              }}
+              _hover={{
+                color: 'blue.500'
+              }}
+              color="blue.300"
+              fontWeight="semibold"
+              href={mapsUrl}
+              isExternal
+            >
+              <Text fontSize="md">
+                📍 Cari Lokasi
+                <ExternalLinkIcon aria-hidden mx={2} />
+              </Text>
+            </Link>
+          </DrawerHeader>
+          <DrawerBody>
+            <Box mb={2}>
+              <Text as="h3" fontSize="lg" fontWeight={700}>
+                💉 Jadwal Vaksinasi{' '}
+                <Badge borderRadius="10">
+                  <Text
+                    as="span"
+                    color={colorMode === 'dark' ? 'gray.300' : 'gray.600'}
+                    fontSize="xs"
+                    fontWeight={400}
+                    gridArea="timestamp"
+                    isTruncated
+                  >
+                    <Text as="time" dateTime={new Date(lastUpdated).toISOString()}>
+                      {formatDistanceToNow(Date.parse(lastUpdated), { locale: idLocale, addSuffix: true })}
+                    </Text>
+                  </Text>
+                </Badge>
+              </Text>
+            </Box>
+            <Divider mb={2} />
+            <Stack direction="column" spacing={8}>
+              {jadwal.map(({ id: jadwalId, waktu }) => (
+                <Box key={jadwalId}>
+                  <Text as="h3" color="gray.500" fontSize="sm" fontWeight={600} mb={2}>
+                    {format(parse(jadwalId, 'yyyy-MM-dd', new Date()), 'PPPP', { locale: idLocale })}
+                  </Text>
+                  <Table size="sm">
+                    <Thead>
+                      <Tr>
+                        <Th>Waktu</Th>
+                        <Th>Sisa Kuota</Th>
+                        <Th>Total Kuota</Th>
+                      </Tr>
+                    </Thead>
+                    <Tbody>
+                      {waktu.map(({ id, kuota }) => {
+                        const { sisaKuota = 0, totalKuota = 0 } = kuota as Kuota;
+                        return (
+                          <Tr key={id}>
+                            <Td>{format(parse(id, 'k:m:s', new Date()), 'p')}</Td>
+                            <Td color={sisaKuota > 0 ? 'green' : 'red'} fontWeight={800}>
+                              {sisaKuota}
+                            </Td>
+                            <Td>{totalKuota}</Td>
+                          </Tr>
+                        );
+                      })}
+                    </Tbody>
+                  </Table>
+                </Box>
+              ))}
+            </Stack>
+          </DrawerBody>
+        </DrawerContent>
+      </Drawer>
     </>
   );
 }

--- a/src/modules/vax/VaxLocationDetail.tsx
+++ b/src/modules/vax/VaxLocationDetail.tsx
@@ -4,21 +4,14 @@ import { Kuota } from '~/data/types';
 import { hasQuota } from '~helpers/QuotaHelpers';
 
 import { VaccinationDataWithDistance } from './types';
+import VaxLocationDetailDrawer from './VaxLocationDetailDrawer';
 
-import { ArrowBackIcon, ExternalLinkIcon } from '@chakra-ui/icons';
 import {
   Badge,
   Box,
   Button,
-  Divider,
-  Drawer,
-  DrawerBody,
-  DrawerContent,
-  DrawerHeader,
-  DrawerOverlay,
   Flex,
   Heading,
-  Link,
   Popover,
   PopoverArrow,
   PopoverBody,
@@ -38,7 +31,7 @@ import {
   Wrap,
   WrapItem
 } from '@chakra-ui/react';
-import { format, formatDistanceToNow, parse } from 'date-fns';
+import { formatDistanceToNow } from 'date-fns';
 import idLocale from 'date-fns/locale/id';
 
 export interface VaxLocationDetailProps {
@@ -57,7 +50,7 @@ export default function VaxLocationDetail({ loading, isUserLocationExist, locati
 
   const {
     nama_lokasi_vaksinasi: namaLokasi,
-    alamat_lokasi_vaksinasi: alamatLokasi,
+    alamat_lokasi_vaksinasi: ignored_alamatLokasi,
     wilayah,
     kecamatan,
     kelurahan,
@@ -87,11 +80,6 @@ export default function VaxLocationDetail({ loading, isUserLocationExist, locati
 
     return null;
   };
-
-  const mapsUrl = detail_lokasi?.[0]
-    ? `https://www.google.com/maps/search/${encodeURIComponent(`${detail_lokasi[0].lat}, ${detail_lokasi[0].lon}`)}`
-    : `https://www.google.com/maps/search/${encodeURIComponent(namaLokasi)}`;
-
   return (
     <>
       <Flex
@@ -175,105 +163,7 @@ export default function VaxLocationDetail({ loading, isUserLocationExist, locati
         </Wrap>
       </Stack>
 
-      <Drawer isOpen={isOpen} onClose={onClose} placement="left" size="md">
-        <DrawerOverlay />
-        <DrawerContent>
-          <Badge
-            fontSize="0.8em"
-            onClick={() => {
-              onClose();
-            }}
-            p={4}
-            style={{ cursor: 'pointer' }}
-          >
-            <ArrowBackIcon h={4} w={4} /> Kembali
-          </Badge>
-          <DrawerHeader borderBottomWidth="1px">
-            <Text as="h1" fontSize="xl" fontWeight={700}>
-              {namaLokasi}
-            </Text>
-            <Text as="h3" color="gray.500" fontSize="xs" fontWeight={500} textTransform="capitalize">
-              {alamatLokasi
-                ? alamatLokasi.toLowerCase()
-                : `Kec. ${kecamatan.toLowerCase()}, Kel. ${kelurahan.toLowerCase()}`}
-            </Text>
-            <Text as="h3" fontSize="sm" fontWeight={600} textTransform="capitalize">
-              {wilayah.toLowerCase()}
-            </Text>
-            <Link
-              _focus={{
-                outline: 'none'
-              }}
-              _hover={{
-                color: 'blue.500'
-              }}
-              color="blue.300"
-              fontWeight="semibold"
-              href={mapsUrl}
-              isExternal
-            >
-              <Text fontSize="md">
-                📍 Cari Lokasi
-                <ExternalLinkIcon aria-hidden mx={2} />
-              </Text>
-            </Link>
-          </DrawerHeader>
-          <DrawerBody>
-            <Box mb={2}>
-              <Text as="h3" fontSize="lg" fontWeight={700}>
-                💉 Jadwal Vaksinasi{' '}
-                <Badge borderRadius="10">
-                  <Text
-                    as="span"
-                    color={colorMode === 'dark' ? 'gray.300' : 'gray.600'}
-                    fontSize="xs"
-                    fontWeight={400}
-                    gridArea="timestamp"
-                    isTruncated
-                  >
-                    <Text as="time" dateTime={new Date(lastUpdated).toISOString()}>
-                      {formatDistanceToNow(Date.parse(lastUpdated), { locale: idLocale, addSuffix: true })}
-                    </Text>
-                  </Text>
-                </Badge>
-              </Text>
-            </Box>
-            <Divider mb={2} />
-            <Stack direction="column" spacing={8}>
-              {jadwal.map(({ id: jadwalId, waktu }) => (
-                <Box key={jadwalId}>
-                  <Text as="h3" color="gray.500" fontSize="sm" fontWeight={600} mb={2}>
-                    {format(parse(jadwalId, 'yyyy-MM-dd', new Date()), 'PPPP', { locale: idLocale })}
-                  </Text>
-                  <Table size="sm">
-                    <Thead>
-                      <Tr>
-                        <Th>Waktu</Th>
-                        <Th>Sisa Kuota</Th>
-                        <Th>Total Kuota</Th>
-                      </Tr>
-                    </Thead>
-                    <Tbody>
-                      {waktu.map(({ id, kuota }) => {
-                        const { sisaKuota = 0, totalKuota = 0 } = kuota as Kuota;
-                        return (
-                          <Tr key={id}>
-                            <Td>{format(parse(id, 'k:m:s', new Date()), 'p')}</Td>
-                            <Td color={sisaKuota > 0 ? 'green' : 'red'} fontWeight={800}>
-                              {sisaKuota}
-                            </Td>
-                            <Td>{totalKuota}</Td>
-                          </Tr>
-                        );
-                      })}
-                    </Tbody>
-                  </Table>
-                </Box>
-              ))}
-            </Stack>
-          </DrawerBody>
-        </DrawerContent>
-      </Drawer>
+      <VaxLocationDetailDrawer isOpen={isOpen} locationData={location} onClose={onClose} />
     </>
   );
 }

--- a/src/modules/vax/VaxLocationDetailDrawer.tsx
+++ b/src/modules/vax/VaxLocationDetailDrawer.tsx
@@ -23,7 +23,8 @@ import {
   Th,
   Thead,
   Tr,
-  useColorMode
+  useColorMode,
+  useColorModeValue
 } from '@chakra-ui/react';
 import { format, formatDistanceToNow, parse } from 'date-fns';
 import idLocale from 'date-fns/locale/id';
@@ -36,6 +37,9 @@ export interface VaxLocationDetailDrawerProps {
 
 export default function VaxLocationDetailDrawer({ isOpen, onClose, locationData }: VaxLocationDetailDrawerProps) {
   const { colorMode } = useColorMode();
+  const subtextColor = useColorModeValue('gray.600', 'gray.300');
+  const kuotaAvailableTextColor = useColorModeValue('green.600', 'green.400');
+  const kuotaEmptyTextColor = useColorModeValue('red.600', 'red.400');
 
   const {
     nama_lokasi_vaksinasi: namaLokasi,
@@ -69,34 +73,36 @@ export default function VaxLocationDetailDrawer({ isOpen, onClose, locationData 
           Kembali
         </Badge>
         <DrawerHeader borderBottomWidth="1px">
-          <Text as="h1" fontSize="xl" fontWeight={700}>
-            {namaLokasi}
-          </Text>
-          <Text as="h3" color="gray.500" fontSize="xs" fontWeight={500} textTransform="capitalize">
-            {alamatLokasi
-              ? alamatLokasi.toLowerCase()
-              : `Kec. ${kecamatan.toLowerCase()}, Kel. ${kelurahan.toLowerCase()}`}
-          </Text>
-          <Text as="h3" fontSize="sm" fontWeight={600} textTransform="capitalize">
-            {wilayah.toLowerCase()}
-          </Text>
-          <Link
-            _focus={{
-              outline: 'none'
-            }}
-            _hover={{
-              color: 'blue.500'
-            }}
-            color="blue.300"
-            fontWeight="semibold"
-            href={mapsUrl}
-            isExternal
-          >
-            <Text fontSize="md">
-              📍 Cari Lokasi
-              <ExternalLinkIcon aria-hidden mx={2} />
+          <Stack direction="column" spacing={2}>
+            <Text as="h1" fontSize="xl" fontWeight={700}>
+              {namaLokasi}
             </Text>
-          </Link>
+            <Text as="h3" color={subtextColor} fontSize="xs" fontWeight={500} textTransform="capitalize">
+              {alamatLokasi
+                ? alamatLokasi.toLowerCase()
+                : `Kec. ${kecamatan.toLowerCase()}, Kel. ${kelurahan.toLowerCase()}`}
+            </Text>
+            <Text as="h3" fontSize="sm" fontWeight={600} textTransform="capitalize">
+              {wilayah.toLowerCase()}
+            </Text>
+            <Link
+              _focus={{
+                outline: 'none'
+              }}
+              _hover={{
+                color: 'blue.500'
+              }}
+              color="blue.300"
+              fontWeight="semibold"
+              href={mapsUrl}
+              isExternal
+            >
+              <Text fontSize="md">
+                📍 Cari Lokasi
+                <ExternalLinkIcon aria-hidden mx={2} />
+              </Text>
+            </Link>
+          </Stack>
         </DrawerHeader>
         <DrawerBody>
           <Box mb={2}>
@@ -125,7 +131,7 @@ export default function VaxLocationDetailDrawer({ isOpen, onClose, locationData 
           <Stack direction="column" spacing={8}>
             {jadwal.map(({ id: jadwalId, waktu }) => (
               <Box key={jadwalId}>
-                <Text as="h3" color="gray.500" fontSize="sm" fontWeight={600} mb={2}>
+                <Text as="h3" color={subtextColor} fontSize="sm" fontWeight={600} mb={2}>
                   {format(parse(jadwalId, 'yyyy-MM-dd', new Date()), 'PPPP', { locale: idLocale })}
                 </Text>
                 <Table size="sm">
@@ -142,7 +148,10 @@ export default function VaxLocationDetailDrawer({ isOpen, onClose, locationData 
                       return (
                         <Tr key={id}>
                           <Td>{format(parse(id, 'k:m:s', new Date()), 'p')}</Td>
-                          <Td color={sisaKuota != null && sisaKuota > 0 ? 'green' : 'red'} fontWeight={800}>
+                          <Td
+                            color={sisaKuota != null && sisaKuota > 0 ? kuotaAvailableTextColor : kuotaEmptyTextColor}
+                            fontWeight={800}
+                          >
                             {sisaKuota}
                           </Td>
                           <Td>{totalKuota}</Td>

--- a/src/modules/vax/VaxLocationDetailDrawer.tsx
+++ b/src/modules/vax/VaxLocationDetailDrawer.tsx
@@ -1,0 +1,161 @@
+import * as React from 'react';
+
+import { Kuota } from '~/data/types';
+
+import { VaccinationDataWithDistance } from './types';
+
+import { ArrowBackIcon, ExternalLinkIcon } from '@chakra-ui/icons';
+import {
+  Badge,
+  Box,
+  Divider,
+  Drawer,
+  DrawerBody,
+  DrawerContent,
+  DrawerHeader,
+  DrawerOverlay,
+  Link,
+  Stack,
+  Table,
+  Tbody,
+  Td,
+  Text,
+  Th,
+  Thead,
+  Tr,
+  useColorMode
+} from '@chakra-ui/react';
+import { format, formatDistanceToNow, parse } from 'date-fns';
+import idLocale from 'date-fns/locale/id';
+
+export interface VaxLocationDetailDrawerProps {
+  locationData: VaccinationDataWithDistance;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function VaxLocationDetailDrawer({ isOpen, onClose, locationData }: VaxLocationDetailDrawerProps) {
+  const { colorMode } = useColorMode();
+
+  const {
+    nama_lokasi_vaksinasi: namaLokasi,
+    alamat_lokasi_vaksinasi: alamatLokasi,
+    wilayah,
+    kecamatan,
+    kelurahan,
+    jadwal,
+    detail_lokasi,
+    last_updated_at: lastUpdated
+  } = locationData;
+
+  const mapsUrl = detail_lokasi?.[0]
+    ? `https://www.google.com/maps/search/${encodeURIComponent(`${detail_lokasi[0].lat}, ${detail_lokasi[0].lon}`)}`
+    : `https://www.google.com/maps/search/${encodeURIComponent(namaLokasi)}`;
+  return (
+    <Drawer isOpen={isOpen} onClose={onClose} placement="left" size="md">
+      <DrawerOverlay />
+      <DrawerContent>
+        <Badge
+          fontSize="0.8em"
+          onClick={() => {
+            onClose();
+          }}
+          p={4}
+          style={{
+            cursor: 'pointer'
+          }}
+        >
+          <ArrowBackIcon h={4} w={4} />
+          Kembali
+        </Badge>
+        <DrawerHeader borderBottomWidth="1px">
+          <Text as="h1" fontSize="xl" fontWeight={700}>
+            {namaLokasi}
+          </Text>
+          <Text as="h3" color="gray.500" fontSize="xs" fontWeight={500} textTransform="capitalize">
+            {alamatLokasi
+              ? alamatLokasi.toLowerCase()
+              : `Kec. ${kecamatan.toLowerCase()}, Kel. ${kelurahan.toLowerCase()}`}
+          </Text>
+          <Text as="h3" fontSize="sm" fontWeight={600} textTransform="capitalize">
+            {wilayah.toLowerCase()}
+          </Text>
+          <Link
+            _focus={{
+              outline: 'none'
+            }}
+            _hover={{
+              color: 'blue.500'
+            }}
+            color="blue.300"
+            fontWeight="semibold"
+            href={mapsUrl}
+            isExternal
+          >
+            <Text fontSize="md">
+              📍 Cari Lokasi
+              <ExternalLinkIcon aria-hidden mx={2} />
+            </Text>
+          </Link>
+        </DrawerHeader>
+        <DrawerBody>
+          <Box mb={2}>
+            <Text as="h3" fontSize="lg" fontWeight={700}>
+              💉 Jadwal Vaksinasi{' '}
+              <Badge borderRadius="10">
+                <Text
+                  as="span"
+                  color={colorMode === 'dark' ? 'gray.300' : 'gray.600'}
+                  fontSize="xs"
+                  fontWeight={400}
+                  gridArea="timestamp"
+                  isTruncated
+                >
+                  <Text as="time" dateTime={new Date(lastUpdated).toISOString()}>
+                    {formatDistanceToNow(Date.parse(lastUpdated), {
+                      locale: idLocale,
+                      addSuffix: true
+                    })}
+                  </Text>
+                </Text>
+              </Badge>
+            </Text>
+          </Box>
+          <Divider mb={2} />
+          <Stack direction="column" spacing={8}>
+            {jadwal.map(({ id: jadwalId, waktu }) => (
+              <Box key={jadwalId}>
+                <Text as="h3" color="gray.500" fontSize="sm" fontWeight={600} mb={2}>
+                  {format(parse(jadwalId, 'yyyy-MM-dd', new Date()), 'PPPP', { locale: idLocale })}
+                </Text>
+                <Table size="sm">
+                  <Thead>
+                    <Tr>
+                      <Th>Waktu</Th>
+                      <Th>Sisa Kuota</Th>
+                      <Th>Total Kuota</Th>
+                    </Tr>
+                  </Thead>
+                  <Tbody>
+                    {waktu.map(({ id, kuota }) => {
+                      const { sisaKuota = 0, totalKuota = 0 } = kuota as Kuota;
+                      return (
+                        <Tr key={id}>
+                          <Td>{format(parse(id, 'k:m:s', new Date()), 'p')}</Td>
+                          <Td color={sisaKuota != null && sisaKuota > 0 ? 'green' : 'red'} fontWeight={800}>
+                            {sisaKuota}
+                          </Td>
+                          <Td>{totalKuota}</Td>
+                        </Tr>
+                      );
+                    })}
+                  </Tbody>
+                </Table>
+              </Box>
+            ))}
+          </Stack>
+        </DrawerBody>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/src/modules/vax/VaxLocationDetailDrawer.tsx
+++ b/src/modules/vax/VaxLocationDetailDrawer.tsx
@@ -14,6 +14,7 @@ import {
   DrawerContent,
   DrawerHeader,
   DrawerOverlay,
+  IconButton,
   Link,
   Stack,
   Table,
@@ -59,21 +60,18 @@ export default function VaxLocationDetailDrawer({ isOpen, onClose, locationData 
     <Drawer isOpen={isOpen} onClose={onClose} placement="left" size="md">
       <DrawerOverlay />
       <DrawerContent>
-        <Badge
-          fontSize="0.8em"
-          onClick={() => {
-            onClose();
-          }}
-          p={4}
-          style={{
-            cursor: 'pointer'
-          }}
-        >
-          <ArrowBackIcon h={4} w={4} />
-          Kembali
-        </Badge>
         <DrawerHeader borderBottomWidth="1px">
           <Stack direction="column" spacing={2}>
+            <Box>
+              <IconButton
+                aria-label="kembali"
+                borderRadius={10}
+                color="blue.300"
+                fontWeight="bold"
+                icon={<ArrowBackIcon />}
+                onClick={onClose}
+              />
+            </Box>
             <Text as="h1" fontSize="xl" fontWeight={700}>
               {namaLokasi}
             </Text>


### PR DESCRIPTION
![vax detail drawer](https://media.giphy.com/media/rRkd1D8MR4djtrHqXa/giphy.gif)

I add a drawer to view the vax location detail and vax schedule easier, esp. on the mobile view.
Maybe with this addition, we can clean up some information on the front page.
