### PR TITLE
refactor `VaxLocationDetail`

### DIFF
--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -10,7 +10,7 @@ export const KuotaRt = rt.Record({
 export const WaktuRt = rt.Record({
   id: rt.String,
   label: rt.Optional(rt.String),
-  kuota: KuotaRt.Or(rt.Record({}))
+  kuota: rt.Optional(KuotaRt)
 });
 
 export const JadwalRt = rt.Record({

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -1,5 +1,4 @@
 import * as rt from 'runtypes';
-import { Optional } from 'runtypes';
 
 export const KuotaRt = rt.Record({
   totalKuota: rt.Union(rt.Null, rt.Number),
@@ -10,7 +9,7 @@ export const KuotaRt = rt.Record({
 
 export const WaktuRt = rt.Record({
   id: rt.String,
-  label: Optional(rt.String),
+  label: rt.Optional(rt.String),
   kuota: KuotaRt.Or(rt.Record({}))
 });
 

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -1,4 +1,5 @@
 import * as rt from 'runtypes';
+import { Optional } from 'runtypes';
 
 export const KuotaRt = rt.Record({
   totalKuota: rt.Union(rt.Null, rt.Number),
@@ -9,7 +10,7 @@ export const KuotaRt = rt.Record({
 
 export const WaktuRt = rt.Record({
   id: rt.String,
-  label: rt.String,
+  label: Optional(rt.String),
   kuota: KuotaRt.Or(rt.Record({}))
 });
 

--- a/src/modules/vax-schedule/VaxLocationSchedulePopover.tsx
+++ b/src/modules/vax-schedule/VaxLocationSchedulePopover.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+
+import { Jadwal } from '~data/types';
+
+import VaxLocationScheduleTable from './VaxLocationScheduleTable';
+
+import { Button, Popover, PopoverArrow, PopoverBody, PopoverContent, PopoverTrigger } from '@chakra-ui/react';
+
+type VaxLocationSchedulePopoverProps = Pick<Jadwal, 'id' | 'label' | 'waktu'>;
+
+export default function VaxLocationSchedulePopover({ id, waktu }: VaxLocationSchedulePopoverProps) {
+  return (
+    <Popover isLazy>
+      <PopoverTrigger>
+        <Button size="sm" variant="outline">
+          {id}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent w={['95vw', '30vw']}>
+        <PopoverArrow />
+        <PopoverBody>
+          <VaxLocationScheduleTable waktu={waktu} />
+        </PopoverBody>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/modules/vax-schedule/VaxLocationScheduleTable.tsx
+++ b/src/modules/vax-schedule/VaxLocationScheduleTable.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+
+import { Kuota, Waktu } from '~data/types';
+
+import { Table, Tbody, Td, Th, Thead, Tr, useColorModeValue } from '@chakra-ui/react';
+
+interface VaxLocationScheduleTableProps {
+  waktu: Waktu[];
+}
+
+export default function VaxLocationScheduleTable({ waktu }: VaxLocationScheduleTableProps) {
+  const kuotaAvailableTextColor = useColorModeValue('green.600', 'green.400');
+  const kuotaEmptyTextColor = useColorModeValue('red.600', 'red.400');
+
+  return (
+    <Table>
+      <Thead>
+        <Tr>
+          <Th>Waktu</Th>
+          <Th>Sisa Kuota</Th>
+          <Th>Total Kuota</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {waktu.map(({ id, kuota }) => {
+          const { sisaKuota = 0, totalKuota = 0 } = kuota as Kuota;
+
+          const kuotaColor = sisaKuota && sisaKuota > 0 ? kuotaAvailableTextColor : kuotaEmptyTextColor;
+
+          return (
+            <Tr key={id}>
+              <Td>{id}</Td>
+              <Td color={kuotaColor} fontWeight={700}>
+                {sisaKuota}
+              </Td>
+              <Td>{totalKuota}</Td>
+            </Tr>
+          );
+        })}
+      </Tbody>
+    </Table>
+  );
+}

--- a/src/modules/vax-schedule/VaxLocationScheduleTable.tsx
+++ b/src/modules/vax-schedule/VaxLocationScheduleTable.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Kuota, Waktu } from '~data/types';
+import { Waktu } from '~data/types';
 
 import { Table, Tbody, Td, Th, Thead, Tr, useColorModeValue } from '@chakra-ui/react';
 
@@ -23,19 +23,23 @@ export default function VaxLocationScheduleTable({ waktu }: VaxLocationScheduleT
       </Thead>
       <Tbody>
         {waktu.map(({ id, kuota }) => {
-          const { sisaKuota = 0, totalKuota = 0 } = kuota as Kuota;
+          if (kuota) {
+            const { sisaKuota = 0, totalKuota = 0 } = kuota;
 
-          const kuotaColor = sisaKuota && sisaKuota > 0 ? kuotaAvailableTextColor : kuotaEmptyTextColor;
+            const kuotaColor = sisaKuota && sisaKuota > 0 ? kuotaAvailableTextColor : kuotaEmptyTextColor;
 
-          return (
-            <Tr key={id}>
-              <Td>{id}</Td>
-              <Td color={kuotaColor} fontWeight={700}>
-                {sisaKuota}
-              </Td>
-              <Td>{totalKuota}</Td>
-            </Tr>
-          );
+            return (
+              <Tr key={id}>
+                <Td>{id}</Td>
+                <Td color={kuotaColor} fontWeight={700}>
+                  {sisaKuota}
+                </Td>
+                <Td>{totalKuota}</Td>
+              </Tr>
+            );
+          }
+
+          return null;
         })}
       </Tbody>
     </Table>

--- a/src/modules/vax-schedule/index.ts
+++ b/src/modules/vax-schedule/index.ts
@@ -1,0 +1,2 @@
+export { default as VaxLocationSchedulePopover } from './VaxLocationSchedulePopover';
+export { default as VaxLocationScheduleTable } from './VaxLocationScheduleTable';

--- a/src/modules/vax/VaxLocationDetail.tsx
+++ b/src/modules/vax/VaxLocationDetail.tsx
@@ -1,30 +1,18 @@
 import * as React from 'react';
 
-import { Kuota } from '~/data/types';
 import { hasQuota } from '~helpers/QuotaHelpers';
+import { VaxLocationSchedulePopover } from '~modules/vax-schedule';
 
 import { VaccinationDataWithDistance } from './types';
 
 import {
   Badge,
   Box,
-  Button,
   Flex,
   Heading,
-  Popover,
-  PopoverArrow,
-  PopoverBody,
-  PopoverContent,
-  PopoverTrigger,
   Stack,
-  Table,
-  Tbody,
-  Td,
   Text,
-  Th,
-  Thead,
   Tooltip,
-  Tr,
   useColorMode,
   useColorModeValue,
   Wrap,
@@ -116,42 +104,9 @@ export default function VaxLocationDetail({ loading, isUserLocationExist, locati
           <Text textTransform="capitalize">{wilayah.toLowerCase()}</Text>
         </Stack>
         <Wrap>
-          {jadwal.map(({ id: jadwalId, waktu }) => (
+          {jadwal.map(({ id: jadwalId, label: jadwalLabel, waktu }) => (
             <WrapItem key={jadwalId}>
-              <Popover isLazy>
-                <PopoverTrigger>
-                  <Button size="sm" variant="outline">
-                    {jadwalId}
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent w={['95vw', '30vw']}>
-                  <PopoverArrow />
-                  <PopoverBody>
-                    <Table>
-                      <Thead>
-                        <Tr>
-                          <Th>Waktu</Th>
-                          <Th>Sisa Kuota</Th>
-                          <Th>Total Kuota</Th>
-                        </Tr>
-                      </Thead>
-                      <Tbody>
-                        {waktu.map(({ id, kuota }) => {
-                          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                          const { sisaKuota = 0, totalKuota = 0 } = kuota as Kuota;
-                          return (
-                            <Tr key={id}>
-                              <Td>{id}</Td>
-                              <Td>{sisaKuota}</Td>
-                              <Td>{totalKuota}</Td>
-                            </Tr>
-                          );
-                        })}
-                      </Tbody>
-                    </Table>
-                  </PopoverBody>
-                </PopoverContent>
-              </Popover>
+              <VaxLocationSchedulePopover id={jadwalId} label={jadwalLabel} waktu={waktu} />
             </WrapItem>
           ))}
         </Wrap>

--- a/src/modules/vax/index.ts
+++ b/src/modules/vax/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+export { default as VaxLocation } from './VaxLocation';
+export { default as VaxLocationDetail } from './VaxLocationDetail';

--- a/src/modules/vax/types.ts
+++ b/src/modules/vax/types.ts
@@ -1,4 +1,4 @@
-import { DetailLokasi, VaccinationData } from '~data/types';
+import type { DetailLokasi, VaccinationData } from '~data/types';
 
 export interface DetailLokasiWithDistance extends DetailLokasi {
   distance?: string | null;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 
 import { getSchedule } from '~data/getSchedule';
-import type { VaccinationDataWithDistance } from '~modules/vax/types';
-import VaxLocation from '~modules/vax/VaxLocation';
+import { VaccinationDataWithDistance, VaxLocation } from '~modules/vax';
 
 import Searchbox from '../components/Searchbox';
 
@@ -180,7 +179,7 @@ export default function HomePage({ schedule }: Props) {
 
     // reset page to 1
     if (currentPage !== 1) {
-      router.push(`/`);
+      void router.push(`/`);
     }
   };
 
@@ -240,7 +239,7 @@ export default function HomePage({ schedule }: Props) {
                     key={i + 1}
                     onClick={() => {
                       const nextPage = i === 0 ? `/` : `/#page=${i + 1}`;
-                      router.push(nextPage).then(() => {
+                      void router.push(nextPage).then(() => {
                         window.scrollTo({ top: 0, behavior: 'smooth' });
                       });
                     }}


### PR DESCRIPTION
- Move vax location schedule popover + table to its own component (allows for use in other components, working on this in another PR)
- add quota colours on `VaxLocationTable`
- handle empty quota properly (hopefully fixes #82)

![image](https://user-images.githubusercontent.com/5663877/125938844-961f2c64-f84e-4913-af7a-f029a86fa00a.png)
